### PR TITLE
Refactor CustomerController and add tests with CI integration

### DIFF
--- a/koi-pond-backend/.github/workflows/ci.yml
+++ b/koi-pond-backend/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Java CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Install dependencies
+        run: mvn install -DskipTests
+
+      - name: Run tests
+        run: mvn test

--- a/koi-pond-backend/src/main/java/org/group/koipondbackend/controller/CustomerController.java
+++ b/koi-pond-backend/src/main/java/org/group/koipondbackend/controller/CustomerController.java
@@ -15,7 +15,6 @@ import lombok.AllArgsConstructor;
 @CrossOrigin("*")
 @AllArgsConstructor
 @RestController
-@Controller
 @RequestMapping("/api/customers")
 public class CustomerController {
     private final CustomerService customerService;

--- a/koi-pond-backend/src/test/java/org/group/koipondbackend/controller/CustomerControllerTest.java
+++ b/koi-pond-backend/src/test/java/org/group/koipondbackend/controller/CustomerControllerTest.java
@@ -1,0 +1,113 @@
+package org.group.koipondbackend.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import java.util.Arrays;
+import java.util.Optional;
+import org.group.koipondbackend.dto.CustomerDTO;
+import org.group.koipondbackend.exception.ResourceNotFoundException;
+import org.group.koipondbackend.service.impl.CustomerService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class CustomerControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private CustomerService customerService;
+
+    @InjectMocks
+    private CustomerController customerController;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        mockMvc = MockMvcBuilders.standaloneSetup(customerController).build();
+    }
+
+    @Test
+    public void testCreateCustomer() throws Exception {
+        CustomerDTO customerDTO = new CustomerDTO();
+        customerDTO.setFullName("John Doe");
+
+        when(customerService.create(any(CustomerDTO.class))).thenReturn(customerDTO);
+
+        mockMvc.perform(post("/api/customers")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(customerDTO)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.fullName").value("John Doe"));
+    }
+
+    @Test
+    public void testGetCustomerById() throws Exception {
+        CustomerDTO customerDTO = new CustomerDTO();
+        customerDTO.setId(1L);
+        customerDTO.setFullName("John Doe");
+
+        when(customerService.findById(anyLong())).thenReturn(Optional.of(customerDTO));
+
+        mockMvc.perform(get("/api/customers/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.fullName").value("John Doe"));
+    }
+
+    @Test
+    public void testGetCustomerById_NotFound() throws Exception {
+        when(customerService.findById(anyLong())).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/customers/1"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testGetAllCustomers() throws Exception {
+        CustomerDTO customer1 = new CustomerDTO();
+        customer1.setFullName("John Doe");
+
+        CustomerDTO customer2 = new CustomerDTO();
+        customer2.setFullName("Jane Doe");
+
+        when(customerService.findAll()).thenReturn(Arrays.asList(customer1, customer2));
+
+        mockMvc.perform(get("/api/customers"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].fullName").value("John Doe"))
+                .andExpect(jsonPath("$[1].fullName").value("Jane Doe"));
+    }
+
+    @Test
+    public void testUpdateCustomer() throws Exception {
+        CustomerDTO customerDTO = new CustomerDTO();
+        customerDTO.setId(1L);
+        customerDTO.setFullName("John Doe");
+
+        when(customerService.update(any(CustomerDTO.class))).thenReturn(customerDTO);
+
+        mockMvc.perform(put("/api/customers/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(customerDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.fullName").value("John Doe"));
+    }
+
+    @Test
+    public void testDeleteCustomer() throws Exception {
+        mockMvc.perform(delete("/api/customers/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Customer deleted successfully"));
+    }
+}

--- a/koi-pond-backend/src/test/java/org/group/koipondbackend/service/impl/CustomerServiceTest.java
+++ b/koi-pond-backend/src/test/java/org/group/koipondbackend/service/impl/CustomerServiceTest.java
@@ -1,0 +1,72 @@
+package org.group.koipondbackend.service.impl;
+
+import org.group.koipondbackend.dto.CustomerDTO;
+import org.group.koipondbackend.entity.Customer;
+import org.group.koipondbackend.mapper.CustomerMapper;
+import org.group.koipondbackend.repository.CustomerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CustomerServiceTest {
+
+    @Mock
+    private CustomerRepository customerRepository;
+
+    @Mock
+    private CustomerMapper customerMapper;
+
+    @InjectMocks
+    private CustomerService customerService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testCustomerServiceCreation() {
+        assertNotNull(customerService);
+    }
+
+    @Test
+    public void testFindAllCustomers() {
+        customerService.findAll();
+        verify(customerRepository).findAll();
+    }
+
+    @Test
+    public void testFindCustomerById() {
+        Long customerId = 1L;
+        customerService.findById(customerId);
+        verify(customerRepository).findById(customerId);
+    }
+
+    @Test
+    public void testDeleteCustomer() {
+        Long customerId = 1L;
+        customerService.delete(customerId);
+    }
+
+    @Test
+    public void testCreateCustomer() {
+        CustomerDTO customerDTO = new CustomerDTO();
+        customerDTO.setFullName("John Doe");
+
+        Customer customer = new Customer();
+        customer.setFullName("John Doe");
+
+        when(customerMapper.toEntity(customerDTO)).thenReturn(customer);
+        when(customerRepository.save(customer)).thenReturn(customer);
+
+        customerService.create(customerDTO);
+
+        verify(customerMapper).toEntity(customerDTO);
+        verify(customerRepository).save(customer);
+    }
+}


### PR DESCRIPTION
This pull request removes the unnecessary `@Controller` annotation from the `CustomerController`, ensuring cleaner code.

Unit tests for both `CustomerController` and `CustomerService`, enhancing test coverage and reliability.

Additionally, a GitHub Actions workflow for Java CI 