### PR TITLE
Add navigation to contact page in header

### DIFF
--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -4,12 +4,17 @@ import Navigation from './Navigation';
 import SearchBar from './SearchBar';
 import LoginButton from './LoginButton';
 
-const Header: React.FC = () => {
+interface HeaderProps {
+    activeMenuItem: string;
+    setActiveMenuItem: (item: string) => void;
+}
+
+const Header: React.FC<HeaderProps> = ({ activeMenuItem, setActiveMenuItem }) => {
     return (
         <header className="bg-white shadow-md">
             <div className="container mx-auto px-4 py-3 flex items-center justify-between">
                 <Logo />
-                <Navigation />
+                <Navigation activeMenuItem={activeMenuItem} setActiveMenuItem={setActiveMenuItem} />
                 <div className="flex items-center space-x-4">
                     <SearchBar />
                     <LoginButton />

--- a/frontend/src/components/layout/Header/Navigation.tsx
+++ b/frontend/src/components/layout/Header/Navigation.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-const Navigation: React.FC = () => {
+interface NavigationProps {
+    activeMenuItem: string;
+    setActiveMenuItem: (item: string) => void;
+}
+
+const Navigation: React.FC<NavigationProps> = ({ activeMenuItem, setActiveMenuItem }) => {
     const navItems = [
         { text: 'Trang chủ', url: '/' },
         { text: 'Mẫu thiết kế', url: '/designs' },
@@ -17,7 +22,8 @@ const Navigation: React.FC = () => {
                     <li key={item.text}>
                         <Link
                             to={item.url}
-                            className="text-gray-600 hover:text-blue-600 transition duration-300"
+                            className={`text-gray-600 hover:text-blue-600 transition duration-300 ${activeMenuItem === item.text ? 'font-bold' : ''}`}
+                            onClick={() => setActiveMenuItem(item.text)}
                         >
                             {item.text}
                         </Link>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Header from './Header/Header';
 import Footer from './Footer/Footer';
 
@@ -7,9 +7,11 @@ interface LayoutProps {
 }
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
+    const [activeMenuItem, setActiveMenuItem] = useState<string>('Trang chủ');
+
     return (
         <div className="flex flex-col min-h-screen">
-            <Header/>
+            <Header activeMenuItem={activeMenuItem} setActiveMenuItem={setActiveMenuItem} />
             <main className="flex-grow">
                 {children}
             </main>


### PR DESCRIPTION
Fixes #6

Add logic to navigate to the "Liên hệ" page from the header.

* **Navigation.tsx**
  - Add `activeMenuItem` and `setActiveMenuItem` props to the `Navigation` component.
  - Update the `Link` elements to use `activeMenuItem` and `setActiveMenuItem` for navigation.

* **Header.tsx**
  - Add `activeMenuItem` and `setActiveMenuItem` props to the `Header` component.
  - Pass `activeMenuItem` and `setActiveMenuItem` to the `Navigation` component.

* **Layout.tsx**
  - Add `useState` to manage `activeMenuItem` state.
  - Pass `activeMenuItem` and `setActiveMenuItem` to the `Header` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/TH-NDang/JavaProject/issues/6?shareId=59c68139-c2f3-444a-a237-69cd8b914dd9).